### PR TITLE
feat: add an effect for clearing the cache globally or per-effect

### DIFF
--- a/src/clear-database.effect.ts
+++ b/src/clear-database.effect.ts
@@ -1,0 +1,60 @@
+import {
+	Effects
+} from '@crowbartools/firebot-custom-scripts-types/types/effects';
+import {
+	modules, settings
+} from './main';
+import template from './clear-database.html';
+import {
+	mediaManager
+} from './media-manager';
+import EffectType = Effects.EffectType;
+
+const wait = (ms: number) => new Promise(resolve => setTimeout(resolve, ms));
+
+interface EffectModel {
+	clearType: 'database' | 'effect';
+	effectId?: string;
+}
+
+interface OverlayData {
+	overlayInstance: string;
+}
+
+const effect: EffectType<EffectModel & OverlayData> = {
+	definition: {
+		id: 'lordmau5:better-random-media:clear-cache',
+		name: 'Better Random Media - Clear Cache',
+		description: 'Clear the cache of played media files.',
+		icon: 'fad fa-eraser',
+		categories: [ 'common' ]
+	},
+	optionsTemplate: template,
+	optionsController: $scope => {
+		if ($scope.effect.clearType == null) {
+			$scope.effect.clearType = 'database';
+		}
+	},
+	optionsValidator: effect => {
+		const errors = [];
+
+		if (effect.clearType === 'effect' && (!effect.effectId || effect.effectId.trim().length !== 36)) {
+			errors.push('Please enter a valid effect ID.');
+		}
+
+		return errors;
+	},
+	onTriggerEvent: async scope => {
+		const effect = scope.effect;
+		if (effect.clearType === 'database') {
+			mediaManager.setAllEffectsUnplayed();
+		}
+
+		else if (effect.clearType === 'effect') {
+			mediaManager.setAllMediaUnplayed(effect.effectId, 'VIDEO');
+			mediaManager.setAllMediaUnplayed(effect.effectId, 'AUDIO');
+		}
+	}
+};
+
+export default effect;

--- a/src/clear-database.html
+++ b/src/clear-database.html
@@ -1,0 +1,18 @@
+<eos-container header="Type">
+	<firebot-radios
+        options="{ database: 'All Effects', effect: 'Specific Effect' }"
+		model="effect.clearType"
+		inline="true"
+		style="padding-bottom: 5px;"
+	/>
+</eos-container>
+
+<eos-container header="Effect" ng-if="effect.clearType === 'effect'" pad-top="true">
+	<firebot-input
+		input-title="Effect ID"
+		title-tooltip="You can copy the ID of an effect via its three-dot menu"
+		model="effect.effectId"
+		placeholder-text="Enter ID"
+		data-type="text"
+	/>
+</eos-container>

--- a/src/media-manager.ts
+++ b/src/media-manager.ts
@@ -119,6 +119,22 @@ class MediaManager {
 		this.updateDatabase(effect_id, type, media);
 	}
 
+	public setAllEffectsUnplayed(): void {
+		const videoEffects: Record<string, Media[]> = this._db.getData(this.getPathForType('VIDEO'));
+
+		Object.values(videoEffects).forEach(medias => {
+			medias.forEach(media => media.played = false);
+		});
+		this._db.push(this.getPathForType('VIDEO'), videoEffects, true);
+
+		const audioEffects: Record<string, Media[]> = this._db.getData(this.getPathForType('AUDIO'));
+
+		Object.values(audioEffects).forEach(medias => {
+			medias.forEach(media => media.played = false);
+		});
+		this._db.push(this.getPathForType('AUDIO'), audioEffects, true);
+	}
+
 	public getUnplayedMedia(effect_id: string, type: MediaType): Media {
 		const media: Media[] = this.getCopy(this.getAllMedia(effect_id, type));
 		if (!media.length) {


### PR DESCRIPTION
Had some people ask for this

This PR adds an effect that lets users clear the cache, either per-effect or globally. The use case is being able to clear the cache automatically (eg. firebot startup, streamdeck button)

Testing:
Ensured global option clears all effects
Ensured ID option only clears for the specific ID
Ensured ID option cannot be saved unless a 36-character string is entered (text length of a UUID, a regex seemed overkill)